### PR TITLE
Remove ZenithServiceNotInitialised alert

### DIFF
--- a/charts/server/templates/metrics/prometheusrule.yaml
+++ b/charts/server/templates/metrics/prometheusrule.yaml
@@ -27,17 +27,6 @@ spec:
     # Zenith service alerts
     - name: zenith.alerts
       rules:
-        - alert: ZenithServiceNotInitialised
-          expr: zenith_service_initialised == 0
-          for: 1h
-          annotations:
-            description: >-
-              Zenith service {{ "{{" }} $labels.service_name {{ "}}" }} has not been initialised for more than one hour.
-            summary: >-
-              Zenith service has not been initialised for more than one hour.
-          labels:
-            severity: warning
-
         # This alert fires when a service has no passing clients
         - alert: ZenithServiceHasNoHealthyClients
           expr: sum(zenith_service_client_status{status="passing"}) by(service_name) == 0


### PR DESCRIPTION
This PR removes the `ZenithServiceNotInitialised` alert, which fires when a Zenith service is registered with the registrar but is never initialised with an SSH public key.

This alert is a symptom of a platform failing to deploy, which is more precisely alerted in other ways, and can only be resolved by directly editing Consul. It is therefore considered to be too noisy.