### PR TITLE
Use build-arg defaults for versions

### DIFF
--- a/.github/workflows/build-push-artifacts.yaml
+++ b/.github/workflows/build-push-artifacts.yaml
@@ -21,14 +21,6 @@ on:
         description: The chart version that was published
         value: ${{ jobs.build_push_chart.outputs.chart-version }}
 
-# Variables controlling the dependencies that are baked in to the image
-env:
-  # proxy
-  NGINX_VERSION: 1.25.3
-  GOMPLATE_VERSION: v3.11.6
-  # sync
-  HELM_VERSION: v3.13.3
-
 jobs:
   build_push_images:
     name: Build and push images
@@ -72,12 +64,6 @@ jobs:
           cache-key: ${{ matrix.component }}
           context: ./${{ matrix.component }}
           platforms: linux/amd64,linux/arm64
-          # We can't use env in the matrix definition, so just specify
-          # the build args for all the builds - they will just go unused
-          build-args: |
-            NGINX_VERSION=${{ env.NGINX_VERSION }}
-            GOMPLATE_VERSION=${{ env.GOMPLATE_VERSION }}
-            HELM_VERSION=${{ env.HELM_VERSION }}
           push: true
           tags: ${{ steps.image-meta.outputs.tags }}
           labels: ${{ steps.image-meta.outputs.labels }}

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -14,25 +14,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - key: helm
-            path: ./.github/workflows/build-push-artifacts.yaml
-            repository: helm/helm
-            version_jsonpath: env.HELM_VERSION
-            component: sync
-
           - key: nginx
-            path: ./.github/workflows/build-push-artifacts.yaml
+            path: ./proxy/Dockerfile
             repository: nginxinc/docker-nginx
             # This repository only publishes tags, not releases
             tags: "yes"
-            version_jsonpath: env.NGINX_VERSION
+            version_jsonpath: NGINX_VERSION
             component: proxy
 
           - key: gomplate
-            path: ./.github/workflows/build-push-artifacts.yaml
+            path: ./proxy/Dockerfile
             repository: hairyhenderson/gomplate
-            version_jsonpath: env.GOMPLATE_VERSION
+            version_jsonpath: GOMPLATE_VERSION
             component: proxy
+
+          - key: helm
+            path: ./sync/Dockerfile
+            repository: helm/helm
+            version_jsonpath: HELM_VERSION
+            component: sync
 
     name: ${{ matrix.key }}
     steps:

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOMPLATE_VERSION
+ARG GOMPLATE_VERSION=v3.11.6
 
 
 # Use a named build stage for gomplate
@@ -21,7 +21,7 @@ RUN gpg2 --keyserver hkp://keyserver.ubuntu.com:80 --keyserver-options timeout=1
 
 FROM ubuntu:jammy
 
-ARG NGINX_VERSION
+ARG NGINX_VERSION=1.25.3
 
 # Copy the GPG key from the intermediate container
 COPY --from=nginx-gpg-key /usr/share/keyrings/nginx-archive-keyring.gpg /usr/share/keyrings/

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install -y curl && \
     rm -rf /var/lib/apt/lists/*
 
-ARG HELM_VERSION
+ARG HELM_VERSION=v3.13.3
 RUN set -ex; \
     OS_ARCH="$(uname -m)"; \
     case "$OS_ARCH" in \

--- a/tilt-component.yaml
+++ b/tilt-component.yaml
@@ -11,6 +11,4 @@ images:
 
   zenith-sync:
     context: ./sync
-    build_args:
-      HELM_VERSION: v3.13.3
     chart_path: sync.image


### PR DESCRIPTION
Using env in the GHA workflow file means that changes to those values are not actually tested, due to the use of `pull_request_target`. So move back to using build-arg defaults in the `Dockerfile`.

Needs https://github.com/stackhpc/github-actions/pull/7.