### PR TITLE
Specify correct chart information for CAPI operator

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -60,7 +60,13 @@ jobs:
           # We deploy one CaaS app (workstation) and a Kubernetes cluster (for the operator) for the test
           extra-vars: |
             zenith_chart_version: ${{ needs.publish_artifacts.outputs.chart-version }}
-            azimuth_capi_operator_zenith_chart_version: ${{ needs.publish_artifacts.outputs.chart-version }}
+            azimuth_capi_operator_release_overrides:
+              config:
+                zenith:
+                  apiserverChartName: zenith-apiserver
+                  operatorChartName: zenith-operator
+                  chartRepository: https://stackhpc.github.io/zenith
+                  chartVersion: ${{ needs.publish_artifacts.outputs.chart-version }}
             generate_tests_caas_test_case_slurm_enabled: false
             generate_tests_caas_test_case_repo2docker_enabled: false
             generate_tests_caas_test_case_rstudio_enabled: false


### PR DESCRIPTION
Since the CAPI operator moved to statically imported charts, we need to specify more information than just the version here.