### PR TITLE
Make Zenith SSHD more robust

### DIFF
--- a/charts/server/templates/sshd/deployment.yaml
+++ b/charts/server/templates/sshd/deployment.yaml
@@ -60,8 +60,7 @@ spec:
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
-            matchLabels:
-              app: {{ include "zenith.componentSelectorLabels" (list . "sshd") | nindent 14 }}
+            matchLabels: {{ include "zenith.componentSelectorLabels" (list . "sshd") | nindent 14 }}
       volumes:
         - name: etc-zenith
           configMap:

--- a/charts/server/templates/sshd/deployment.yaml
+++ b/charts/server/templates/sshd/deployment.yaml
@@ -55,6 +55,13 @@ spec:
       {{- with .Values.sshd.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: {{ include "zenith.componentSelectorLabels" (list . "sshd") | nindent 14 }}
       volumes:
         - name: etc-zenith
           configMap:

--- a/charts/server/templates/sshd/deployment.yaml
+++ b/charts/server/templates/sshd/deployment.yaml
@@ -57,7 +57,7 @@ spec:
       {{- end }}
       topologySpreadConstraints:
         - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
+          topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:

--- a/charts/server/templates/sshd/poddisruptionbudget.yaml
+++ b/charts/server/templates/sshd/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "zenith.componentname" (list . "sshd") }}
   labels: {{ include "zenith.componentLabels" (list . "sshd") | nindent 4 }}
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels: {{ include "zenith.componentSelectorLabels" (list . "sshd") | nindent 6 }}
 {{- end }}

--- a/charts/server/templates/sshd/poddisruptionbudget.yaml
+++ b/charts/server/templates/sshd/poddisruptionbudget.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.sshd.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "zenith.componentname" (list . "sshd") }}
+  labels: {{ include "zenith.componentLabels" (list . "sshd") | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels: {{ include "zenith.componentSelectorLabels" (list . "sshd") | nindent 6 }}
+{{- end }}

--- a/charts/server/templates/sshd/role.yaml
+++ b/charts/server/templates/sshd/role.yaml
@@ -29,4 +29,10 @@ rules:
       - create
       - patch
       - delete
+  - apiGroups:
+      - zenith.stackhpc.com
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - "*"
 {{- end }}

--- a/charts/server/templates/sshd/role.yaml
+++ b/charts/server/templates/sshd/role.yaml
@@ -29,10 +29,4 @@ rules:
       - create
       - patch
       - delete
-  - apiGroups:
-      - zenith.stackhpc.com
-    resources:
-      - poddisruptionbudgets
-    verbs:
-      - "*"
 {{- end }}

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -72,7 +72,7 @@ sshd:
     tag: ""  # Defaults to appVersion if not given
   imagePullSecrets: []
   # The number of SSHD replicas to use
-  replicaCount: 1
+  replicaCount: 3
   # Customise annotations for SSHD pods
   podAnnotations: {}
   # Customise pod-level security context for SSHD pods


### PR DESCRIPTION
- [ ] Set SSHD replicas to 3 by default
- [ ] Use [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) to ensure those 3 pods are spread over the workers as evenly as possible (i.e. `maxSkew: 1`)
- [ ] Use [pod disruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) with `maxUnavailable: 1` to ensure that only one SSHD pod is killed at once